### PR TITLE
Reset relations when permissions are updated or deleted

### DIFF
--- a/src/Role.php
+++ b/src/Role.php
@@ -56,7 +56,7 @@ class Role extends Model
             $this->grant($permission);
         });
 
-        $this-refresh();
+        $this->setRelations([]);
     }
 
     /**
@@ -103,8 +103,12 @@ class Role extends Model
      */
     public function revoke($permission)
     {
-        if (\is_string($permission)) {
-            return Permission::findOrFail($permission)->delete();
+        if (\is_string($permission)) {           
+            Permission::findOrFail($permission)->delete();
+            
+            $this->setRelations([]);
+
+            return true;
         }
 
         return false;
@@ -115,7 +119,11 @@ class Role extends Model
      */
     public function revokeAll()
     {
-        return $this->getPermissions()->delete();
+        $this->getPermissions()->delete();
+        
+        $this->setRelations([]);
+        
+        return true;
     }
 
     /**

--- a/src/Role.php
+++ b/src/Role.php
@@ -52,9 +52,11 @@ class Role extends Model
 
         $this->revokeAll();
 
-        collect($permissions)->map(function ($permission) {
+        collect($permissions)->each(function ($permission) {
             $this->grant($permission);
         });
+
+        $this-refresh();
     }
 
     /**
@@ -90,8 +92,6 @@ class Role extends Model
             'role_id'         => $this->id,
             'permission_slug' => $permission,
         ]);
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
In my feature and unit tests I am creating users with specific permissions for certain scenarios, this means that I am calling `setPermissions` multiple times in a test and during this process I have encountered the below issues which this PR fixes.

**Scenario A** 
When you call the `setPermissions` method the `$role->getPermissions` relation returns the previous set of permissions as the model is not refreshed. Changed it so that it calls the `setRelations` method in `setPermissions` to reset the relation. 

<details>
<summary>Code example to replicate issue</summary>

**Code**
```php
$role = \Pktharindu\NovaPermissions\Role::create(['slug' => 'admin']);

$role->setPermissions(['view clients']);

dump([
    'not refreshed is empty' => $role->getPermissions->pluck('permission_slug')->toArray(),
    'refreshed' => $role->refresh()->getPermissions->pluck('permission_slug')->toArray(),
]);
```

**Output**
```sh
array:2 [
  "not refreshed is empty" => []
  "refreshed" => array:1 [
    0 => "view clients"
  ]
]
```
</details>


**Scenario B** 
If you call `setPermissions` multiple times on the same model instance where some permissions already exist they get deleted by the `revokeAll` method. Then the `hasPermission` method is called which is using a non-refreshed `getPermissions` relation.  Added calls to `setRelations` to the revoke methods.

<details>
<summary>Code example to replicate issue</summary>

**Code**
```php
$role = \Pktharindu\NovaPermissions\Role::create(['slug' => 'admin']);

$role->setPermissions(['view clients']);

dump([
    'permission created ok' => $role->refresh()->getPermissions->pluck('permission_slug')->toArray(),
]);

$role->setPermissions(['view clients', 'manage clients']);

dump([
    'updated permissions' => $role->refresh()->getPermissions->pluck('permission_slug')->toArray(),
]);
```

**Current Output**
```sh
array:1 [
  "permission created ok" => array:1 [
    0 => "view clients"
  ]
]
array:1 [
  "updated permissions" => array:1 [
    0 => "manage clients" // only new permission exists, 'view clients' was deleted but not recreated :(
  ]
]
```

**Fixed Output**
```sh
array:1 [
  "permission created ok" => array:1 [
     0 => "view clients"
  ]
]
array:1 [
  "updated permissions" => array:1 [
      0 => "manage clients"
      1 => "view clients"
  ]
]
```
</details>

Made a couple other minor tweaks that do not affect functionality.