### PR TITLE
BelongsToMany fails into HasRoles when name of role_user is changed

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -13,7 +13,7 @@ trait HasRoles
      */
     public function roles()
     {
-        return $this->belongsToMany(Role::class)->with('getPermissions');
+        return $this->belongsToMany(Role::class, config('nova-permissions.table_names.role_user', 'role_user'))->with('getPermissions');
     }
 
     /**


### PR DESCRIPTION
If you change the name of role_user table, the Trait HasRoles fails in checks the permissions.