### PR TITLE
Use `Laravel\Nova\Resource` instead of `App\Nova\Resource`

### DIFF
--- a/src/Nova/Role.php
+++ b/src/Nova/Role.php
@@ -2,7 +2,7 @@
 
 namespace Pktharindu\NovaPermissions\Nova;
 
-use App\Nova\Resource;
+use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;


### PR DESCRIPTION
Hi, this fix an exception thrown if you have nova resource under a different namespace