### PR TITLE
Allow for customizing keyType for Roles model

### DIFF
--- a/config/nova-permissions.php
+++ b/config/nova-permissions.php
@@ -27,6 +27,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Key type value for the Role model
+    |--------------------------------------------------------------------------
+    | Allows to use nova-permissions with all UUID based migrations
+    */
+
+    'role_model_key_type' =>  'int',
+
+    /*
+    |--------------------------------------------------------------------------
     | Database table names
     |--------------------------------------------------------------------------
     | When using the "HasRoles" trait from this package, we need to know which

--- a/src/Role.php
+++ b/src/Role.php
@@ -8,6 +8,8 @@ use Pktharindu\NovaPermissions\Policies\Policy;
 
 class Role extends Model
 {
+    protected $keyType = config('nova-permissions.key_type', 'int');
+
     protected $fillable = [
         'slug',
         'name',

--- a/src/Role.php
+++ b/src/Role.php
@@ -8,7 +8,7 @@ use Pktharindu\NovaPermissions\Policies\Policy;
 
 class Role extends Model
 {
-    protected $keyType = config('nova-permissions.key_type', 'int');
+    protected $keyType = config('nova-permissions.role_model_key_type', 'int');
 
     protected $fillable = [
         'slug',


### PR DESCRIPTION
Work in progress.

Without this PR it is impossible to use UUID/ULID as a key in nova-permissions migrations because it causes unintended casting to `int` type (default key type value) and as a result error on the screen below:
![image](https://github.com/user-attachments/assets/5fe05657-046c-441b-9893-2d5384698055)
